### PR TITLE
add password support, examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ Manage linux users.
     $ sparrow plg run user --param name=sparrow --param uid=2500 --param gid=1300
     $ sparrow plg run user --param name=sparrow --param managehome=no
     $ sparrow plg run user --param name=sparrow --param action=delete
+    $ sparrow plg run user --param name=sparrow --param action=create --param password=12345
 
 ## via sparrowdo
 
     task-run 'create user sparrow', 'user', %(
       action   => 'create',
       name     => 'sparrow',
+      password => '12345',
       home_dir => '/opt/sparrow',
       uid      => 453,
       gid      => 2300,
@@ -32,6 +34,10 @@ Manage linux users.
 ## name
 
 User name. Obligatory.
+
+## password
+
+Password for user.
 
 ## new_login
 

--- a/examples/main.pl6
+++ b/examples/main.pl6
@@ -1,0 +1,23 @@
+set_spl %( dev-user => 'https://github.com/Spigell/user' );
+
+my $user = 'sparrow';
+
+task-run "create user $user", 'dev-user', %(
+  action   => 'create',
+  name     => "$user",
+  uid      => '4000',
+  home_dir => "/home/$user",
+  groups   => 'wheel',
+);
+
+task-run "change user $user", 'dev-user', %(
+  name     => "$user",
+  uid      => '4005',
+  home_dir => "/tmp/$user",
+  groups   => 'wheel',
+);
+
+task-run "remove user $user", 'dev-user', %(
+  action   => 'delete',
+  name     => "$user",
+);

--- a/examples/password.pl6
+++ b/examples/password.pl6
@@ -1,0 +1,25 @@
+set_spl %( dev-user => 'https://github.com/Spigell/user' );
+
+my $user = 'test';
+
+package-install ( 'sshpass' );
+
+task-run "create user $user", 'dev-user', %(
+  action   => 'create',
+  name     => "$user",
+  password => "12345",
+  home_dir => "/home/$user",
+  groups   => 'wheel',
+);
+
+bash "sshpass -p 12345 ssh  -o StrictHostKeychecking=no $user@127.0.0.1 'exit 0' ";
+
+task-run "change user $user", 'dev-user', %(
+  action   => 'create',
+  name     => "$user",
+  password => "1234567",
+  home_dir => "/tmp/$user",
+  groups   => 'wheel',
+);
+
+bash "sshpass -p 1234567 ssh  -o StrictHostKeychecking=no $user@127.0.0.1 'exit 0' ";

--- a/modules/change/story.bash
+++ b/modules/change/story.bash
@@ -19,6 +19,7 @@ gid=$(config gid)
 managehome=$(config managehome)
 homedir=$(config home_dir)
 groups=$(config groups)
+password=$(config password)
 
 
 if [[ -n $uid ]]; then
@@ -35,6 +36,7 @@ fi
 if [[ -n $gid ]]; then
   gid=" -g $gid"
 fi
+
 
 current_user_id=`id $user`
 old_user_home=$(grep $user /etc/passwd | cut -f 6 -d ":")
@@ -65,9 +67,12 @@ if [[ -n $new_login ]]    || \
    [[ -n $gid ]]          || \
    [[ -n $homedir_args ]] || \
    [[ -n $groups ]]; then
-   usermod $name $new_login $uid $gid $homedir_args $groups 
+   usermod $new_login $uid $gid $homedir_args $groups $name
 fi 
 
+if [[ -n $password ]]; then
+  echo $name:$password | chpasswd
+fi
 
 # Validate user by login
 if [[ -n $newlogin ]]; then

--- a/modules/create/story.bash
+++ b/modules/create/story.bash
@@ -1,3 +1,5 @@
+debug=$(config debug)
+[[ $debug ]] && set -x
 set -e
 
 user=$(config name)
@@ -57,7 +59,12 @@ fi
 if [[ $os == alpine ]]; then
   adduser $home_key $homedir $name $uid $gid $groups -D
 else
-  useradd $home_key $homedir $name $uid $gid $groups
+  useradd $home_key $homedir $uid $gid $groups $name 
+fi
+
+if [[ -n $password ]]; then
+  echo "set password..."
+  echo $name:$password | chpasswd
 fi
 
 id $user && echo "user $user created"

--- a/modules/create/story.bash
+++ b/modules/create/story.bash
@@ -8,6 +8,7 @@ gid=$(config gid)
 managehome=$(config managehome)
 homedir=$(config home_dir)
 groups=$(config groups)
+password=$(config password)
 
 if [[ -n $uid ]]; then
   uid=" -u $uid"


### PR DESCRIPTION
Здравствуйте. Добавил поддержку установления пароля через chpasswd (не уверен, что будет работать на alpine). 
Добавил два примера.
Также, переместил имя пользователя в конец команд useradd и usermod, так как так правильней и на старых пакетах по-другому вызывает ошибку ( пробовал на centos 6 с пакетом shadow-utils-4.1.4.2-13.el6.x86_64).